### PR TITLE
client_lib: remove unused error.h import  rom zeroconf-detail

### DIFF
--- a/src/client_lib/zeroconf-detail.hpp
+++ b/src/client_lib/zeroconf-detail.hpp
@@ -15,7 +15,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
 #else
-#include <error.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>


### PR DESCRIPTION
This fixes building on non-glibc systems like Alpine Linux.

Fixes https://github.com/MayaPosch/NymphCast/issues/7