### PR TITLE
Create a symlink to libnymphcast.so.<version>

### DIFF
--- a/src/client_lib/Makefile
+++ b/src/client_lib/Makefile
@@ -66,6 +66,7 @@ lib/$(OUTPUT).a: $(OBJECTS)
 	
 lib/$(OUTPUT).so.$(VERSION): $(SHARED_OBJECTS)
 	$(GCC) -o $@ $(CFLAGS) $(SHARED_FLAGS) $(SHARED_OBJECTS) $(LIBS)
+	@ln -s $@ $(OUTPUT).so
 	
 makedir:
 	$(MAKEDIR) lib


### PR DESCRIPTION
This way distributions that split out a -dev package don't have to manually do this and specify a <version> which will change over time. I will do the same for nymphrpc