### PR TITLE
Update Alpine package names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ For **pacman** based distros (ArchLinux, Manjaro), some packages exist for:
 
 For Alpine Linux and postmarketOS, packages are available in the **testing** repository:
 
-* the server: [nymphcast-server](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/nymphcast)
-* the sdk: [nymphcast-sdk](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/nymphcast-sdk)
+* the server: [nymphcast-server](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/nymphcast-server)
+* the sdk: [nymphcast-dev](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/nymphcast-dev)
 * the player: [nymphcast-client](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/nymphcast-client)
 
 ## Goals ##


### PR DESCRIPTION
The packaging switched around a bit in Alpine and makes a lot more sense now.

The SDK is available in `nymphcast-dev` which includes the necessary library symlink and header files. This will automatically install the `nymphcast` package which includes the library itself. The server is available in `nymphcast-server` with the init file being available at `nymphcast-server-openrc`.