### PR TITLE
Add .gitattributes configuration file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Git line endings
+
+# Automatically normalize line endings:
+* text=auto
+
+# Always use LF for bash scripts to enable access via Windows file share:
+*.sh text eol=lf
+
+# Mark as binary (when required):
+#*.xxx binary
+
+# Exclude files from exporting:
+.gitattributes  export-ignore
+.gitignore      export-ignore


### PR DESCRIPTION
My use case:

- Work with this GitHub repository under MS-Windows. This currently gives native CR/LF line endings for text files.
- Setup / Build NymphCast under MSYS2.

In this situation, `./setup.sh` has CR/LF instead of LF line endings and it is not recognised as a valid script.

With the `.gitattributes` file of this PR in place, script files will have LF line endings an be usable as scripts.