### PR TITLE
Makefile paths

### DIFF
--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -185,6 +185,7 @@ install-systemd:
 install-openrc:
 	install -d $(DESTDIR)$(CONFDIR)/init.d/	
 	sed ${SED_REPLACE} openrc/nymphcast > $(DESTDIR)$(CONFDIR)/init.d/nymphcast
+	chmod 0755 $(DESTDIR)$(CONFDIR)/init.d/nymphcast
 
 
 # Construct an archive for Raspbian: audio-only, or full.

--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -102,10 +102,10 @@ else
 	CONFDIR := /etc
 endif
 
-SED_REPLACE := -e 's:@BIN@:$(DESTDIR)$(PREFIX)/bin/$(TARGET_BIN)$(OUTPUT):g' \
-	-e 's:@CONFIG@:$(DESTDIR)$(CONFDIR)/nymphcast/nymphcast_config.ini:g' \
-	-e 's:@APPS@:$(DESTDIR)$(PREFIX)/share/nymphcast/apps/:g' \
-	-e 's:@WALLPAPERS@:$(DESTDIR)$(PREFIX)/share/nymphcast/wallpapers/:g'
+SED_REPLACE := -e 's:@BIN@:$(PREFIX)/bin/$(OUTPUT):g' \
+	-e 's:@CONFIG@:$(CONFDIR)/nymphcast/nymphcast_config.ini:g' \
+	-e 's:@APPS@:$(PREFIX)/share/nymphcast/apps/:g' \
+	-e 's:@WALLPAPERS@:$(PREFIX)/share/nymphcast/wallpapers/:g'
 
 all: makedir bin/$(TARGET_BIN)$(OUTPUT)
 


### PR DESCRIPTION
DESTDIR is used by distribution packaging to determine paths for make to
install too, which always is some other location than the root of the
filesystem. The resulting package will then install it to the root on
user systems. Thus, using DESTDIR in the Makefile causes wrong paths to
be used

Also, the binaries are always installed to $PREFIX/bin, not
$PREFIX/linux-<arch>-<whatever>/bin, and same with all other files
(config, apps, etc). Thus remove $(TARGET_BIN) from the bin path.

Also OpenRC init files need to be executable to prevent a "Permission denied" error.