### PR TITLE
Build fixes (FreeBSD, Clang)

### DIFF
--- a/src/server/ffplaydummy.h
+++ b/src/server/ffplaydummy.h
@@ -19,6 +19,8 @@
 #include <queue>
 #include <functional>
 
+#include <cmath>
+
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_mutex.h>
 

--- a/src/server/gui/app/ScraperCmdLine.cpp
+++ b/src/server/gui/app/ScraperCmdLine.cpp
@@ -5,10 +5,10 @@
 #include "SystemData.h"
 #include <iostream>
 #include <signal.h>
-#if defined(__linux__)
-#include <unistd.h>
-#elif defined(WIN32)
+#if defined(WIN32)
 #include <Windows.h>
+#else
+#include <unistd.h>
 #endif
 
 std::ostream& out = std::cout;

--- a/src/server/gui/app/components/TextListComponent.h
+++ b/src/server/gui/app/components/TextListComponent.h
@@ -30,7 +30,7 @@ protected:
 	using IList<TextListData, T>::getTransform;
 	using IList<TextListData, T>::mSize;
 	using IList<TextListData, T>::mCursor;
-	using IList<TextListData, T>::Entry;
+	using typename IList<TextListData, T>::Entry;
 
 public:
 	using IList<TextListData, T>::size;

--- a/src/server/gui/core/components/ImageGridComponent.h
+++ b/src/server/gui/core/components/ImageGridComponent.h
@@ -40,7 +40,7 @@ protected:
 	using IList<ImageGridData, T>::getTransform;
 	using IList<ImageGridData, T>::mSize;
 	using IList<ImageGridData, T>::mCursor;
-	using IList<ImageGridData, T>::Entry;
+	using typename IList<ImageGridData, T>::Entry;
 	using IList<ImageGridData, T>::mWindow;
 
 public:

--- a/src/server/gui/core/utils/FileSystemUtil.cpp
+++ b/src/server/gui/core/utils/FileSystemUtil.cpp
@@ -25,6 +25,15 @@
 #include <unistd.h>
 #endif // _WIN32
 
+#ifdef __FreeBSD__
+// FreeBSD doesn't have a stat / stat64 distinction: everything is already
+// 64-bit clean.
+#include <sys/stat.h>
+#define stat64 stat
+static inline int lstat64(const char * path, struct stat64 *sb) { return ::lstat(path, sb); }
+#endif
+
+
 //////////////////////////////////////////////////////////////////////////
 
 namespace Utils


### PR DESCRIPTION
Here's a handful of fixes related to #62 . With these, plus some packaging-specific things which I'll describe in that issue, NymphCast builds (and runs, at least long enough to complain I should have given it a configuration file).
