### PR TITLE
Add CMake support to NymphcastPlayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ src/server/wallpapers/*.png
 src/server/wallpapers/*.jpeg
 *.class
 *.txt
+!CMakeLists.txt
 *.out.*
 *.iml
 .gradle

--- a/doc/building_nymphcast_player.md
+++ b/doc/building_nymphcast_player.md
@@ -29,22 +29,27 @@ sudo pacman -S qt5-base
 
 ## Building ##
 
-Option 1: The project's `.pro` file can be loaded in the Qt Creator IDE and the project built from there.
-
-Option 2: Manual building using `qmake` & `make` commands.
-
-
+The project can be built with QMake or with CMake.
 Either way, obtain and install the NymphRPC & LibNymphCast dependencies:
 
 1. Check-out [NymphRPC](https://github.com/MayaPosch/NymphRPC) elsewhere and build the library per the provided instructions.
 2. Check-out [LibNymphCast](https://github.com/MayaPosch/libnymphcast) elsewhere and build the library per the provided instructions.
 
 When building on the command line, follow one of the following sections.
+Otherwise both options can be loaded into any IDE like the Qt Creator IDE and built from there.
 
 ### **Linux and similar** ###
 
-1. Download or clone the project repository 
-2. Navigate to `player/NymphCastPlayer` folder in the project files.
+#### CMake
+1. Download or clone the project repository
+2. Navigate to the `player` folder in the project files.
+3. Trigger CMake `cmake -B build`
+4. Build it: `cmake --build build`
+5. The player binary is created as `build/NymphCastPlayer/nymphcast-player`
+
+#### QMake
+1. Download or clone the project repository
+2. Navigate to the `player/NymphCastPlayer` folder in the project files.
 3. Create build folder: `mkdir build` and enter it: `cd build`
 4. Trigger QMake: `qmake ..`
 5. Build with Make: `make`

--- a/player/CMakeLists.txt
+++ b/player/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.6.0)
+
+project(nymphcast-player
+	VERSION 0.1
+	DESCRIPTION "The reference client for the Nymphcast protocol")
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
+
+include(FeatureSummary)
+include(GNUInstallDirs)
+
+set(QT_MIN_VERSION "5.15.0")
+find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
+find_package(Poco COMPONENTS Net REQUIRED)
+
+add_subdirectory(NymphCastPlayer)
+
+feature_summary(WHAT ALL)

--- a/player/NymphCastPlayer/CMakeLists.txt
+++ b/player/NymphCastPlayer/CMakeLists.txt
@@ -1,0 +1,103 @@
+set(SRC
+	container_qpainter.cpp
+	litehtml/src/background.cpp
+	litehtml/src/box.cpp
+	litehtml/src/context.cpp
+	litehtml/src/css_length.cpp
+	litehtml/src/css_selector.cpp
+	litehtml/src/document.cpp
+	litehtml/src/el_anchor.cpp
+	litehtml/src/el_base.cpp
+	litehtml/src/el_before_after.cpp
+	litehtml/src/el_body.cpp
+	litehtml/src/el_break.cpp
+	litehtml/src/el_cdata.cpp
+	litehtml/src/el_comment.cpp
+	litehtml/src/el_div.cpp
+	litehtml/src/el_font.cpp
+	litehtml/src/el_image.cpp
+	litehtml/src/el_li.cpp
+	litehtml/src/el_link.cpp
+	litehtml/src/el_para.cpp
+	litehtml/src/el_script.cpp
+	litehtml/src/el_space.cpp
+	litehtml/src/el_style.cpp
+	litehtml/src/el_table.cpp
+	litehtml/src/el_td.cpp
+	litehtml/src/el_text.cpp
+	litehtml/src/el_title.cpp
+	litehtml/src/el_tr.cpp
+	litehtml/src/element.cpp
+	litehtml/src/gumbo/attribute.c
+	litehtml/src/gumbo/char_ref.c
+	litehtml/src/gumbo/error.c
+	litehtml/src/gumbo/parser.c
+	litehtml/src/gumbo/string_buffer.c
+	litehtml/src/gumbo/string_piece.c
+	litehtml/src/gumbo/tag.c
+	litehtml/src/gumbo/tokenizer.c
+	litehtml/src/gumbo/utf8.c
+	litehtml/src/gumbo/util.c
+	litehtml/src/gumbo/vector.c
+	litehtml/src/html.cpp
+	litehtml/src/html_tag.cpp
+	litehtml/src/iterators.cpp
+	litehtml/src/media_query.cpp
+	litehtml/src/num_cvt.cpp
+	litehtml/src/style.cpp
+	litehtml/src/stylesheet.cpp
+	litehtml/src/table.cpp
+	litehtml/src/utf8_strings.cpp
+	litehtml/src/web_color.cpp
+	main.cpp
+	mainwindow.cpp
+	qlitehtmlwidget.cpp
+	remotes.cpp
+	custom_remotes.cpp)
+
+set(HEADERS
+	container_qpainter.h
+	container_qpainter_p.h
+	mainwindow.h
+	qlitehtml_global.h
+	qlitehtmlwidget.h
+	remotes.h
+	custom_remotes.h)
+
+include_directories("litehtml/include")
+include_directories("litehtml/include/litehtml")
+include_directories("litehtml/src/gumbo/include")
+include_directories("litehtml/src/gumbo/include/gumbo")
+
+qt_add_resources(RESOURCES resources.qrc)
+
+if (ANDROID)
+	add_library(nymphcast-player ${SRC} ${HEADERS} ${RESOURCES})
+else()
+	add_executable(nymphcast-player ${SRC} ${HEADERS} ${RESOURCES})
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
+
+add_definitions(-D__NCVERSION=${PROJECT_VERSION})
+
+target_link_libraries(nymphcast-player
+	Qt5::Gui
+	Qt5::Widgets
+	Poco::Net
+	nymphcast
+	nymphrpc)
+
+if (ANDROID)
+	target_link_libraries(nymphcast-player
+		Qt5::AndroidExtras)
+
+	set(ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_CURRENTG_SOURCE_DIR}/android)
+elif(WIN32)
+	target_link_libraries(nymphcast-player
+		ws2_32)
+endif()
+
+install(TARGETS nymphcast-player RUNTIME
+	DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
QMake is slowly being deprecated by the Qt project. From Qt 6.0 and onwards Qt itself is already building with CMake and not with QMake anymore and it's only a matter of time til QMake itself will be removed.

This commit introduces the CMake build system and successfully builds the project for at least Linux.

I haven't managed to test the Windows support as I don't have or use Windows and neither Android support as I fail to build Poco properly for Android...

```
/home/bart/Documents/Git/nymphcast/poco/Foundation/src/Thread_POSIX.cpp:94:7: error: use of undeclared identifier 'pthread_getname_np'
                if (pthread_getname_np(pthread_self(), name, POCO_MAX_THREAD_NAME_LEN + 1))
                    ^
```