### PR TITLE
server: Add missing include <cstdint>

### DIFF
--- a/src/server/sarge.h
+++ b/src/server/sarge.h
@@ -1,13 +1,13 @@
 /*
 	sarge.h - Header file for the Sarge command line argument parser project.
-	
+
 	Revision 0
-	
+
 	Notes:
 			-
-			 
+
 	2019/03/16, Maya Posch
-	
+
 */
 
 
@@ -19,6 +19,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <cstdint>
 
 
 struct Argument {
@@ -42,7 +43,7 @@ class Sarge {
 	std::string description;
 	std::string usage;
 	std::vector<std::string> textArguments;
-	
+
 public:
 	void setArgument(std::string arg_short, std::string arg_long, std::string desc, bool hasVal);
 	void setArguments(std::vector<Argument> args);


### PR DESCRIPTION
Fails to build with musl libc and gcc 15 because uint32_t is used without including cstdint:

In file included from sarge.cpp:17:
sarge.h:54:30: error: 'uint32_t' has not been declared
   54 |         bool getTextArgument(uint32_t index, std::string &value);
      |                              ^~~~~~~~
sarge.h:22:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   21 | #include <memory>
  +++ |+#include <cstdint>
   22 |