### PR TITLE
Use a POSIX-compatible chmod

### DIFF
--- a/src/server/Makefile
+++ b/src/server/Makefile
@@ -240,7 +240,7 @@ install:
 	install -m 755 bin/$(TARGET_BIN)$(OUTPUT) $(DESTDIR)$(PREFIX)/bin/
 	install -m 644 *.ini $(DESTDIR)$(CONFDIR)/nymphcast/
 	cp -r apps/* $(DESTDIR)$(PREFIX)/share/nymphcast/apps/
-	chmod --recursive a+X $(DESTDIR)$(PREFIX)/share/nymphcast/apps/
+	chmod -R a+X $(DESTDIR)$(PREFIX)/share/nymphcast/apps/
 	install -m 644 wallpapers/*.jpg $(DESTDIR)$(PREFIX)/share/nymphcast/wallpapers/
 	
 .PHONY: uninstall


### PR DESCRIPTION
`--recursive` seems to be a GNUism and is not supported by Busybox's implementation of `chmod`. `-R` is and does the same thing.